### PR TITLE
Feature/5 run toolkit with ollama

### DIFF
--- a/docs/configuring-llm.md
+++ b/docs/configuring-llm.md
@@ -47,6 +47,13 @@ LLM_EMBEDDINGS_SERVICE=ollama
 
 then restart the api with `docker compose restart api`
 
+> NOTE: The `OLLAMA_BASEURL` above may change based on your operating system and ollama installation.  
+The example above assumes a standard installation on a linux machine and uses `172.17.0.1` as the default gateway between the docker network and the host (`host.docker.internal` on MacOS and Windows) . `localhost` and `127.0.0.1` will typically **NOT** work. 
+
+> **IMPORTANT: Ollama must be listening to all local interfaces**. By default a standard ollama installation will listen to `localhost` and `127.0.0.1`, both unreachable from a 
+docker container. To fix this, set `OLLAMA_HOST=0.0.0.0`. See [here](https://github.com/ollama/ollama/issues/703) for more details
+
+
 ### Configuring the application settings
 
 In settings.yaml or app.yaml settings section add the following lines

--- a/docs/configuring-llm.md
+++ b/docs/configuring-llm.md
@@ -34,7 +34,7 @@ ollama pull nomic-embed-text
 Locate the file `./data/api/.env` and add the following configurations
 
 ```ini
-OLLAMA_URL=http://172.17.0.1:11434
+OLLAMA_BASEURL=http://172.17.0.1:11434
 
 OLLAMA_MODEL=phi3
 OLLAMA_CHAT_MODELS=phi3:*

--- a/docs/customize-application.md
+++ b/docs/customize-application.md
@@ -75,8 +75,14 @@ background: milkyway
 # It will be also used to translate conversation as needed
 language: en-GB
 
-# LLM provider, defaults to OpenAI
-llm: default
+# LLM provider and models for each functionality
+llm:
+  chat: openai/gpt-4o
+  tools: openai/gpt-4o
+  sentiment: openai/gpt-4o-mini
+  tasks: openai/gpt-4o-mini
+  intent: openai/gpt-4o
+  translation: openai/gpt-4o-mini
 
 # default avatar prompt, this will be used as baseline in conversations.
 # This prompt defines the overall direction of the conversation along with the avatar specific prompt

--- a/docs/toolkit-api/configuration.md
+++ b/docs/toolkit-api/configuration.md
@@ -198,7 +198,7 @@ Default OpenAI model used as fallback (default: `gpt-4o`)
 LiteLLM endpoint URL (default: `http://litellm`)
 
 
-#### OLLAMA_URL 
+#### OLLAMA_BASEURL 
 
 Url to Ollama (default: `http://ollama:11434`)
 


### PR DESCRIPTION
This PR addresses a few problems emerged while investigating https://github.com/sermas-eu/sermas-toolkit-api/issues/5

When using ollama without an OpenAPI key, application could silently fallback to OpenAPI calls.

Changes in multiple repos are needed. See first comment.

PRs include:
- Improved logs and some code refactoring
- Reviewed documentation
- Reviewed configuration (changed variable names and defaults)